### PR TITLE
Update PROCFILE and externalize port as environment variable

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-  web: node index.js
+web: node app.js

--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
 var app = require('./server/server.js');
 
-app.listen(8000);
+var port = process.env.PORT || 4568;
+
+app.listen(port);
+
+console.log('Server now listening on port ' + port);


### PR DESCRIPTION
Updated PROCFILE to use app.js, instead of index.js.  Also, updated server.js so that it uses environment variable as port if exist.  Otherwise, it uses 4568 as default port#.  With these changes, we can deploy our app to Heroku.  Here is the link to the deployed app on Heroku:
https://germ-tracker.herokuapp.com/

@jjmerino, @kmeurer, @jamesongamble, @suprbh - please review and merge this PR.
