### PR TITLE
Remove unnecessary require statement which causes Heroku app not to startup

### DIFF
--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,6 +1,5 @@
 var userController = require('../controllers/userController');
 var helpers = require('../lib/helpers');
-var expect = require('expect.js');
 
 module.exports = function (app) {
 


### PR DESCRIPTION
This should fix an issue with our deployed app on Heroku
