### PR TITLE
Add reported_cases table and new REST endpoints

### DIFF
--- a/server/config/serverConfig.js
+++ b/server/config/serverConfig.js
@@ -22,6 +22,7 @@ module.exports = function (app, express) {
   var userRouter = express.Router();
   var locationRouter = express.Router();
   var proximityRouter = express.Router();
+  var caseRouter = express.Router();
 
   require('./passport')(passport); // pass passport for configuration
 
@@ -39,18 +40,19 @@ module.exports = function (app, express) {
   app.set('views', __dirname + '/../views');
   app.engine('ejs', engine);
   app.set('view engine', 'ejs');
-  // require('express-helpers')(app);
 
   app.use(express.static(__dirname + './../pubic'));
   app.use("/mobile", express.static(__dirname + "./../../mobile/www"));
 
   app.use('/api/users', userRouter);
   app.use('/api/locations', locationRouter);
+  app.use('/api/cases', caseRouter);
   app.use('/api/proximity', proximityRouter);
   app.use('/auth', authRouter);
-  app.use('/', commonRouter);;
+  app.use('/', commonRouter);
 
   require('../routes/authRoutes.js')(authRouter);
+  require('../routes/caseRoutes.js')(caseRouter);
   require('../routes/commonRoutes.js')(commonRouter);
   require('../routes/userRoutes.js')(userRouter);
   require('../routes/locationRoutes.js')(locationRouter);

--- a/server/controllers/caseController.js
+++ b/server/controllers/caseController.js
@@ -1,0 +1,40 @@
+var ReportedCase = require('../database/dbSchema').ReportedCase;
+
+module.exports = {
+
+  getAllReportedCases: function(req, res, next) {
+    ReportedCase.findAll({ limit: 100 })
+      .success(function(reportedCases) {
+        res.status(200).send(reportedCases);
+      });
+  },
+
+  getReportedCase: function(req, res, next) {
+    ReportedCase.find(req.params.id).then(function(reportedCase) {
+      res.status(200).send(reportedCase);
+    });
+  },
+
+  createNewCase: function(req, res, next) {
+    ReportedCase.create({
+      disease_id: req.body.disease_id,
+      latitude: req.body.latitude,
+      longitude: req.body.longitude,
+      date: req.body.date,
+      description: req.body.description })
+      .success(function(reportedCase) {
+        res.setHeader('Content-Type', 'application/json');
+        res.status(201).send(reportedCase.dataValues);
+      })
+      .error(function(err) {
+        res.status(400).send({ error: err.name, message: err.message });
+      });
+  },
+
+  showAllReportedCase: function(req, res, next) {
+    ReportedCase.findAll({ order: 'created_at DESC', limit: 100 }).
+      success(function(reportedCases) {
+        res.render('locations', { locations: reportedCases });
+      });
+  }
+};

--- a/server/database/dbSchema.js
+++ b/server/database/dbSchema.js
@@ -59,6 +59,16 @@ var Proximity = sequelize.define('proximity', {
   tableName: 'proximity'
 });
 
+var ReportedCase = sequelize.define('reported_case', {
+  id: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+  description: { type: Sequelize.STRING },
+  date: { type: Sequelize.DATE, allowNull: false },
+  latitude: { type: Sequelize.FLOAT, allowNull: false },
+  longitude: { type: Sequelize.FLOAT, allowNull: false }
+}, {
+  tableName: 'reported_cases'
+});
+
 /*** DEFINE RELATIONSHIPS ***/
 
 User.hasMany(Location, {
@@ -77,6 +87,8 @@ Proximity.belongsTo(Disease);
 Disease.hasMany(User, { joinTableName: 'user_diseases' });
 User.hasMany(Disease, { joinTableName: 'user_diseases' });
 
+Disease.hasMany(ReportedCase);
+ReportedCase.belongsTo(Disease);
 
 /*** Authenticate, connect, and create tables if they are not already defined ***/
 
@@ -141,6 +153,7 @@ module.exports = {
   Disease: Disease,
   User: User,
   Proximity: Proximity,
+  ReportedCase: ReportedCase,
   sequelize: sequelize, // we expose this for testing
   saveUser: saveUser,
   findUser: findUser,

--- a/server/routes/caseRoutes.js
+++ b/server/routes/caseRoutes.js
@@ -1,0 +1,12 @@
+var caseController = require('../controllers/caseController');
+var helpers = require('../lib/helpers');
+
+module.exports = function (app) {
+  app.route('/')
+    .get(caseController.getAllReportedCases)
+    .post(caseController.createNewCase);
+  app.route('/:id')
+    .get(caseController.getReportedCase)
+    .put(helpers.invalidMethodHandler)
+    .delete(helpers.invalidMethodHandler);
+};

--- a/specs/server/cases.spec.js
+++ b/specs/server/cases.spec.js
@@ -1,0 +1,130 @@
+var db = require('../../server/database/dbSchema.js');
+var request = require('supertest');
+var expect = require('chai').expect;
+var app = require('../../server/server.js');
+
+describe('Reported Cases Test Suite', function() {
+
+  var disease_id;
+
+  before(function(done) {
+    db.sequelize.sync({ force: true }).success(function() {
+      db.Disease.create({ name: "Ebola" })
+        .success(function(disease) {
+          disease_id = disease.id;
+          done();
+        });
+    });
+  });
+
+  describe('GET: /api/cases', function() {
+    it('should return a list of cases', function(done) {
+      db.ReportedCase.bulkCreate([
+        {
+          disease_id: disease_id,
+          latitude: 12.678,
+          longitude: 23.456,
+          date: Date.now(),
+          description: "Ebola is bad"
+        },
+        {
+          disease_id: disease_id,
+          latitude: 12.345,
+          longitude: 23.456,
+          date: Date.now(),
+          description: "Ebola is really bad"
+        }
+      ])
+        .success(function(cases) {
+          request(app)
+            .get('/api/cases')
+            .expect(200)
+            .end(function(err, res) {
+              expect(res.body.length).to.be.equal(2);
+              expect(res.body[0].latitude).to.equal(12.678);
+              done();
+            });
+        });
+      });
+  });
+
+  describe('GET: /api/cases/:id', function() {
+    it('should return a single case', function(done) {
+      db.ReportedCase.create({
+        disease_id: disease_id,
+        latitude: 12.345,
+        longitude: 23.456,
+        date: Date.now(),
+        description: "Ebola is bad"
+      }).then(function(created) {
+        request(app)
+          .get('/api/cases/' + created.id)
+          .expect(200)
+          .end(function(err, res) {
+            expect(res.body.latitude).to.equal(12.345);
+            done();
+          });
+      });
+    });
+
+    it('should respond an empty result if not exist', function(done) {
+      request(app)
+        .get('/api/cases/' + 3000)
+        .expect(200)
+        .end(function(err, res) {
+          expect(res.body).to.deep.equal({});
+          done();
+        });
+    });
+  });
+
+  describe('POST: /api/cases', function() {
+    it('should return an error message upon invalid request', function(done) {
+      request(app)
+        .post('/api/cases')
+        .send( {disease_id: disease_id })
+        .expect(400)
+        .end(function(req, res) {
+          expect(res.body.message).to.be.equal('Validation error');
+          done();
+        });
+    });
+
+    it('should insert a new case', function(done) {
+      request(app)
+        .post('/api/cases')
+        .send({
+          disease_id: disease_id,
+          latitude: 14.252,
+          longitude: 20.523,
+          date: Date.now(),
+          description: "Ebola is really bad"
+        })
+        .expect(201)
+        .end(function(err, res) {
+          if (err) {
+            done(err);
+          }
+
+          db.ReportedCase.find(res.body.id)
+            .success(function(found) {
+               expect(found.dataValues.latitude).to.be.equal(14.252);
+              expect(found.dataValues.longitude).to.be.equal(20.523);
+              done();
+            });
+        });
+    });
+  });
+
+  describe('PUT/DELETE: /api/cases', function() {
+    it('should return "Method not allowed" error', function(done) {
+      request(app)
+        .delete('/api/cases/1')
+        .expect(404)
+        .end(function(req, res) {
+          expect(res.body.message).to.be.equal('Method not allowed');
+          done();
+        });
+    });
+  });
+});

--- a/specs/server/routes.spec.js
+++ b/specs/server/routes.spec.js
@@ -4,6 +4,7 @@ var request = require('supertest');
 var app = require('../../server/server');
 var userController = require('../../server/controllers/userController');
 var locationController = require('../../server/controllers/locationController');
+var caseController = require('../../server/controllers/caseController');
 var proximityController = require('../../server/controllers/proximityController');
 var authController = require('../../server/controllers/authController');
 var helpers = require('../../server/lib/helpers');
@@ -240,6 +241,71 @@ describe('Route Test Suites', function() {
         .end(function(err, res) {
           expect(proximityController.getDiseaseIndexes.called).to.be.true;
           proximityController.getDiseaseIndexes.restore();
+          done();
+        });
+    });
+  });
+
+  describe('Case Routes Tests', function() {
+
+    it('should invoke caseController.getAllReportedCases when receiving a GET request to /api/cases', function(done) {
+      sinon.spy(caseController, 'getAllReportedCases');
+
+      request(app)
+        .get('/api/cases')
+        .end(function(err, res) {
+          expect(caseController.getAllReportedCases.called).to.be.true;
+          caseController.getAllReportedCases.restore();
+          done();
+        });
+    });
+
+    it('should invoke caseController.getReportedCase when receiving a GET request to /api/cases/:id', function(done) {
+      sinon.spy(caseController, 'getReportedCase');
+
+      request(app)
+        .get('/api/cases/1')
+        .end(function(err, res) {
+          expect(caseController.getReportedCase.called).to.be.true;
+          caseController.getReportedCase.restore();
+          done();
+        });
+    });
+
+    it('should invoke caseController.createNewCase when receiving a GET request to /api/cases/', function(done) {
+      sinon.spy(caseController, 'createNewCase');
+
+      request(app)
+        .post('/api/cases')
+        .send({ disease_id: 1, latitude: 12.252 * 0.001, longitude: 21.523423 * 0.001, date: Date.now() })
+        .end(function(err, res) {
+          expect(caseController.createNewCase.called).to.be.true;
+          caseController.createNewCase.restore();
+          done();
+        });
+    });
+
+    it('should invoke helpers.invalidMethodHandler when receiving a PUT request to /api/cases/:id', function(done) {
+      sinon.spy(helpers, 'invalidMethodHandler');
+
+      request(app)
+        .put('/api/cases/1')
+        .send({ description: 'foo' })
+        .end(function(err, res) {
+          expect(helpers.invalidMethodHandler.called).to.be.true;
+          helpers.invalidMethodHandler.restore();
+          done();
+        });
+    });
+
+    it('should invoke helpers.invalidMethodHandler when receiving a DELETE request to /api/cases/:id', function(done) {
+      sinon.spy(helpers, 'invalidMethodHandler');
+
+      request(app)
+        .del('/api/cases/1')
+        .end(function(err, res) {
+          expect(helpers.invalidMethodHandler.called).to.be.true;
+          helpers.invalidMethodHandler.restore();
           done();
         });
     });


### PR DESCRIPTION
We now have a new table "reported_cases" and ReportedCase REST endpoints.  We currently allow only read and create operations for now.  This endpoint will be used to show all reported cases in our mobile's Map view.

cc: @jjmerino, @kmeurer, @jamesongamble, @suprbh 
