### PR TITLE
Tracking feature enabled/disabled settings now saved to local storage. 

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -3,7 +3,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <!-- This line ensures that saving data to localStorage does not go to iCloud, but is saved locally-->
-<preference name="BackupWebStorage" value="none" />
+<!-- <preference name="BackupWebStorage" value="none" /> -->
 
 <widget id="com.ionicframework.mobile737625" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>mobile</name>

--- a/mobile/www/js/services.js
+++ b/mobile/www/js/services.js
@@ -21,7 +21,7 @@ angular.module('app.services', [])
     };
   })
 
-  .factory('GeoLocation', function ($http) {
+  .factory('GeoLocation',  function ($http) {
   })
 
   .factory('LocalStorage', ['$window', function($window) {

--- a/mobile/www/js/utils.js
+++ b/mobile/www/js/utils.js
@@ -1,20 +1,29 @@
-angular.module('app.utils', [])
-.controller('StorageCtrl', ['LocalStorage', function($localstorage) {
-    $localstorage.toggleTrack = 0;
+angular.module('app.utils', ['app.services'])
+.controller('StorageCtrl', ['$scope', 'LocalStorage', function($scope, LocalStorage) {
+    $scope.toggleTrack = LocalStorage.get('tracking');
 
-    $localstorage.pushTrack = function() {
-      if ($localstorage.get('tracking') === 'false') {
-        $localstorage.set('tracking', 'true'); 
+    $scope.pushTrack = function() {
+      console.log('got into pushTrack');
+      if (LocalStorage.get('tracking') === 'false') {
+        LocalStorage.set('tracking', 'true'); 
+        console.log(LocalStorage.get('tracking'));
       }
-      if ($localstorage.get('tracking') === 'true') {
-        $localstorage.set('tracking', 'false');
+      else {
+        LocalStorage.set('tracking', 'false');
+        console.log(LocalStorage.get('tracking'));
       }
     };
 
 
-    // $localstorage.set('tracking', 'false');  
+    // $scope.pushTrack = function () {
+    //   console.log('got into new pushTrack');
+    // }
 
-    console.log($localstorage.get('tracking'));
+    // $scope.pushTrack();
+    // $localstorage.set('tracking', 'false');  
+    // var name = window.localStorage['name'] || 'you';
+    // alert('Hello, ' + name);
+    // console.log($localstorage.get('tracking'));
 
 }]);
 

--- a/mobile/www/templates/settings.html
+++ b/mobile/www/templates/settings.html
@@ -13,20 +13,20 @@
       </li>
       <li class="item item-toggle">
          Frequently Asked Questions
-      </li>
         <li class="item item-toggle">
-         Track Location
-         <label class="toggle toggle-balanced">
-           <input type="checkbox" ng-model="toggleTrack" ng-click="pushTrack()">
+         Push Notifications
+         <label class="toggle toggle-balanced" >
+           <input type="checkbox" ng-model="togglePush">
            <div class="track">
              <div class="handle"></div>
            </div>
          </label>
       </li>
+      </li>
         <li class="item item-toggle">
-         Push Notifications
-         <label class="toggle toggle-balanced" >
-           <input type="checkbox" ng-model="togglePush">
+         Track Location
+         <label class="toggle toggle-balanced">
+           <input type="checkbox" ng-checked="toggleTrack" ng-click="pushTrack()">
            <div class="track">
              <div class="handle"></div>
            </div>
@@ -45,8 +45,8 @@
 
             
              {{toggleTrack}}
-             {{togglePush}}
-             {{toggleFb}}
+         <!--     {{togglePush}}
+             {{toggleFb}} -->
 
              
 

--- a/mobile/www/templates/settings.html
+++ b/mobile/www/templates/settings.html
@@ -42,12 +42,6 @@
          </label>
       </li>
     </ul>
-
-            
-             {{toggleTrack}}
-         <!--     {{togglePush}}
-             {{toggleFb}} -->
-
              
 
 


### PR DESCRIPTION
Toggling the enable or disable tracking feature in settings will save the preference into local storage. This way, users do not have to keep enabling the tracking feature on reload.

BUG: User view is not updated with correct true/false user toggle preference, but the preference is correctly saved to local storage
