### PR TITLE
Refactor error handling code to fix an error caused by signup failure

### DIFF
--- a/mobile/www/js/controllers/user.js
+++ b/mobile/www/js/controllers/user.js
@@ -11,7 +11,7 @@ angular.module('app.controllers.user', [])
         })
         .catch(function (error) {
           alert(error.data.error);
-          $location.path('/signup');
+          $location.path('/signin');
         });
     };
 

--- a/mobile/www/js/services/auth.js
+++ b/mobile/www/js/services/auth.js
@@ -11,8 +11,6 @@ angular.module('app.services.auth', [])
           AuthTokenService.setToken(resp.data.token);
           LocalStorageService.setItem('user_id', resp.data.user);
           return resp;
-        }, function(err) {
-          console.error(err);
         });
     };
 
@@ -33,8 +31,6 @@ angular.module('app.services.auth', [])
           AuthTokenService.setToken(resp.data.token);
           LocalStorageService.setItem('user_id', resp.data.user);
           return resp;
-        }, function(err) {
-          console.error(err);
         });
     };
 

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -69,7 +69,7 @@ module.exports = {
         if (user) {
           var alreadyExist = new Error('This user account already exists');
           alreadyExist.status = 400;
-          next(alreadyExist);
+          throw alreadyExist;
         } else {
           // make a new user if not exist
           return User.create({

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -52,7 +52,7 @@ module.exports = {
               }
             });*/
           var token = jwt.encode(user, jwtSecret);
-          res.json({token: token, user: user});
+          res.json({token: token, user: user.id});
         }
       })
       .fail(function (error) {
@@ -75,21 +75,12 @@ module.exports = {
           return User.create({
             email: username,
             password: password
-          });
+          })
+            .then(function(user) {
+              var token = jwt.encode(user, jwtSecret);
+              res.json({token: token, user: user.id});
+            });
         }
-      })
-      .then(function(user) {
-        // create token to send back for auth
-        var token = jwt.encode(user, jwtSecret);
-        var newUser = {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          created_at: user.created_at,
-          updated_at: user.updated_at,
-          gender: user.gender
-        };
-        res.json({token: token, user: newUser});
       })
       .fail(function (error) {
         next(error);


### PR DESCRIPTION
This is a fix to https://github.com/germTheory/germTheoryWebApp/issues/327.

The fix is to re-throw an error when a user already exists and let fail clause handle this condition, rather than handling it separately.  Also, removed error clause in signup/signin methods in auth services to return error back to user controller so that it can handle error directly.

cc: @jjmerino, @kmeurer, @jamesongamble, @suprbh 
